### PR TITLE
Feature - Spec file for RPM and alternate theme root directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+################################################################################
+# Makefile - Makefile for installing rabe-icecast-theme
+################################################################################
+#
+# Copyright (C) 2017 Radio Bern RaBe
+#                    Switzerland
+#                    http://www.rabe.ch
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public 
+# License as published  by the Free Software Foundation, version
+# 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License  along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+# Please submit enhancements, bugfixes or comments via:
+# https://github.com/radiorabe/rabe-icecast-theme
+#
+# Authors:
+#  Christian Affolter <c.affolter@purplehaze.ch>
+
+PN = rabe-icecast-theme
+
+# Standard commands according to
+# https://www.gnu.org/software/make/manual/html_node/Makefile-Conventions.html
+SHELL = /bin/sh
+INSTALL = /usr/bin/install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# Standard directories according to
+# https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html#Directory-Variables
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+datarootdir = $(prefix)/share
+datadir = $(datarootdir)
+docdir = $(datarootdir)/doc/$(PN)
+sbindir = $(exec_prefix)/sbin
+sysconfdir = $(prefix)/etc
+libdir = $(exec_prefix)/lib
+
+.PHONY: all
+all:
+
+
+.PHONY: installdirs
+installdirs:
+	$(INSTALL) -d $(DESTDIR)$(datadir)/$(PN)/admin \
+		      $(DESTDIR)$(datadir)/$(PN)/web \
+		      $(DESTDIR)$(docdir)
+
+
+.PHONY: install
+install: all installdirs
+	$(INSTALL_DATA) admin/* $(DESTDIR)$(datadir)/$(PN)/admin
+	$(INSTALL_DATA) web/* $(DESTDIR)$(datadir)/$(PN)/web
+	$(INSTALL_DATA) README.md $(DESTDIR)$(docdir)/
+
+
+.PHONY: uninstall
+uninstall:
+	rm -rf $(DESTDIR)$(datadir)/$(PN)/
+	rm -rf $(DESTDIR)$(docdir)/

--- a/README.md
+++ b/README.md
@@ -1,38 +1,85 @@
-# Initial deploy
+# Radio Bern RaBe Icecast web theme
+[Icecast](http://icecast.org/) streaming server web layout (CSS, HTML and
+images) for [Radio Bern RaBe](http://www.rabe.ch) based on the original Icecast
+layout.
 
-Login to stream.rabe.ch as root.
 
-	cd ~
-	cd /usr/share/
+## Installation via RPM on CentOS
+The RaBe Icecast web theme is packaged for CentOS 7 and available on [Radio
+RaBe's Audio Packages for Enterprise Linux
+repository](https://build.opensuse.org/project/show/home:radiorabe:audio). It
+can be installed as follows:
 
-Backup original configuration:
+```bash
+# Install the RaBe APEL repository configuration
+curl -o /etc/yum.repos.d/home:radiorabe:audio.repo \
+     http://download.opensuse.org/repositories/home:/radiorabe:/audio/CentOS_7/home:radiorabe:audio.repo
 
-	mv icecast icecast.orig
+# Install the package
+yum install rabe-icecast-theme
+```
 
-Install templates from the git repository:
+[Configure the Icecast server](#icecast-configuration) to use the new theme.
 
-	git clone https://github.com/radiorabe/rabe-icecast-theme.git
-	mv ~/rabe-icecast-theme /usr/share/icecast
 
-Restore authentication configs from original files:
+## Manual installation
+For all other distributions you can manually install the RaBe Icecast web theme
+via Git (make sure you have `git` installed):
 
-	mv icecast.orig/auth/ icecast/
+```bash
+# Install the web theme from the git repository:
+cd /usr/local/share
+git clone https://github.com/radiorabe/rabe-icecast-theme.git
 
-Fix permissions for all files:
+# To update the web theme
+cd /usr/local/share/rabe-icecast-theme
+git pull
+```
 
-	find /usr/share/icecast -type d -exec chmod 755 {} \;
-	find /usr/share/icecast -type f -exec chmod 644 {} \;
+[Configure the Icecast server](#icecast-configuration) to use the new theme.
 
-# Update templates from repository
+## Icecast configuration
+The Icecast server must be configured to use the newly installed web theme.
+Edit the Icecast configuration XML and point the `webroot` and `adminroot` to
+the new theme directories:
+```bash
+vi /etc/icecast.xml
+```
 
-Login to stream.rabe.ch as root:
+```xml
+<icecast>
+    <!-- [...] -->
+    <paths>
+        <!-- [...] -->
+        <webroot>/usr/share/rabe-icecast-theme/web</webroot>
+        <adminroot>/usr/share/rabe-icecast-theme/admin</adminroot>
+        <!-- [...] -->
+    </paths>
+    <!-- [...] -->
+</icecast>
+```
 
-	cd /usr/share/icecast
-	git pull
-	Already up-to-date.
+Adapt the paths above to `/usr/local/share/rabe-icecast-theme` for manual
+installations.
+
+Or the same changes via sed:
+```bash
+sed -i \
+    -e 's|^\([[:space:]]*<webroot>\).*\(</webroot>\)|\1/usr/share/rabe-icecast-theme/web\2|' \
+    -e 's|^\([[:space:]]*<adminroot>\).*\(</adminroot>\)|\1/usr/share/rabe-icecast-theme/admin\2|' \
+    /etc/icecast.xml
+```
+
+Finally, restart the Icecast server and enjoy the new RaBe theme :-)
+
+```bash
+systemctl restart icecast.service
+```
 
 ## License
+rabe-icecast-theme is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by the
+Free Software Foundation, version 3 of the License.
 
-rabe-icecast-theme is released under the terms of the GNU Affero General Public License.
-Copyright 2015-2017 Radio RaBe.
-See `LICENSE` for further information.
+## Copyright
+Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)

--- a/rabe-icecast-theme.spec
+++ b/rabe-icecast-theme.spec
@@ -1,0 +1,63 @@
+#
+# spec file for package rabe-icecast-theme
+#
+# Copyright (c) 2017 Radio Bern RaBe
+#                    http://www.rabe.ch
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public 
+# License as published  by the Free Software Foundation, version
+# 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License  along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+# Please submit enhancements, bugfixes or comments via GitHub:
+# https://github.com/radiorabe/rabe-icecast-theme
+#
+
+Name:           rabe-icecast-theme
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Radio Bern RaBe Icecast web theme
+
+License:        AGPL
+BuildArch:      noarch
+URL:            https://github.com/radiorabe/%{name}
+Source0:        https://github.com/radiorabe/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+
+%description
+Icecast streaming server web layout (CSS, HTML and images) for Radio Bern RaBe.
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+
+%build
+
+
+%install
+make install prefix=%{_prefix} \
+             exec_prefix=%{_exec_prefix} \
+             datarootdir=%{_datarootdir} \
+             datadir=%{_datadir} \
+             docdir=%{_docdir}/%{name} \
+             DESTDIR=%{?buildroot}
+
+
+%files
+%doc %{_docdir}/%{name}/README.md
+%{_datadir}/%{name}/*
+
+
+%changelog
+* Thu Nov 23 2017 Christian Affolter <c.affolter@purplehaze.ch> - 0.1.0-1
+- Initial release


### PR DESCRIPTION
The following PR adds a Makefile for installing/uninstalling the RaBe icecast web theme and a Spec file for building an RPM.

Apart from that, the installation was adapted so that it no longer overwrites the original Icecast web/admin root path (`/usr/share/icecast`), but instead uses a dedicated theme root-directory (`/usr/share/rabe-icecast-theme`). This prevents messing with directories and files installed by the Icecast RPM.